### PR TITLE
feat(llm): add QAT/Pruning/Sparsity model config support (#115)

### DIFF
--- a/src/pygpukit/llm/__init__.py
+++ b/src/pygpukit/llm/__init__.py
@@ -585,7 +585,13 @@ from pygpukit.llm.layers import (  # noqa: E402
 )
 
 # Loaders (refactored v0.2.11)
-from pygpukit.llm.loader import (  # noqa: E402
+# Quantization/Optimization configs (v0.2.18 - Issue #115)
+from pygpukit.llm.loader import (  # noqa: E402  # noqa: E402
+    FP8QuantConfig,
+    ModelOptimizationInfo,
+    PruningConfig,
+    QATQuantConfig,
+    SparsityConfig,
     load_gpt2_from_safetensors,
     load_llama_from_safetensors,
     load_mixtral_from_safetensors,
@@ -685,4 +691,10 @@ __all__ = [
     "DecodeBatch",
     "DecodeSpeculative",
     "DecodeJacobi",
+    # Quantization/Optimization configs (v0.2.18 - Issue #115)
+    "FP8QuantConfig",
+    "QATQuantConfig",
+    "PruningConfig",
+    "SparsityConfig",
+    "ModelOptimizationInfo",
 ]


### PR DESCRIPTION
## Summary

Add support for loading models optimized with QAT, pruning, and sparsity techniques.

Closes #115

### New Config Classes

- **QATQuantConfig**: Parse QAT/QAD configs from TensorRT Model Optimizer and HuggingFace formats
- **PruningConfig**: Detect structured/unstructured pruning configs
- **SparsityConfig**: Support 2:4 structured sparsity patterns for Ampere+ TensorCores
- **ModelOptimizationInfo**: Aggregate all optimization info

### Supported Formats

| Format | Source | Detection |
|--------|--------|-----------|
| NVFP4/FP8/INT8 | TensorRT Model Optimizer | `producer` + `quantization` fields |
| AWQ/GPTQ/BNB | HuggingFace | `quantization_config.quant_method` |
| Pruned heads | HuggingFace | `pruned_heads` field |
| 2:4 sparsity | Various | `sparsity_config.pattern` |

### Usage Example

```python
from pygpukit.llm import ModelOptimizationInfo

# Parse all optimizations from config.json
opt_info = ModelOptimizationInfo.from_config(config)

if opt_info.has_any_optimization():
    print(opt_info.summary())  # e.g., "FP8(e4m3), Pruned(structured)"

# Check specific optimizations
if opt_info.sparsity_config and opt_info.sparsity_config.is_2_4_sparse():
    print("Model uses 2:4 structured sparsity")
```

## Test plan

- [x] Unit test config parsing for all formats
- [x] Pre-commit checks pass (ruff, mypy)
- [x] Build succeeds

## Future Work (out of scope for this PR)

- [ ] Sparse GEMM kernels for 2:4 sparsity
- [ ] QAT weight loading with learned scales
- [ ] TensorRT-LLM checkpoint format support

🤖 Generated with [Claude Code](https://claude.com/claude-code)